### PR TITLE
Simplified the 'Real' production

### DIFF
--- a/annotated-grammar.rst
+++ b/annotated-grammar.rst
@@ -124,7 +124,7 @@ construction "t.12" could be tokenised as "ID REAL" instead of the
 manageable "ID PERIOD INTEGER", so we write out the real and imaginary
 productions using the INTEGER token to force the latter token sequence. ::
     
-    real = ((INTEGER "." {INTEGER})|("." INTEGER))[("E"|"e") ["+"|"-"] INTEGER ]
+    real = ((INTEGER "." [INTEGER])|("." INTEGER))[("E"|"e") ["+"|"-"] INTEGER ]
 
 An imaginary number is a real or integer followed by the letter "j". ::
     


### PR DESCRIPTION
Current rule of the real production allows and INTEGER followed by a dot and one or more INTEGERs. Since INTEGER refers to an integer number and not individual digits, it would be sufficient to only allow a single repetition.