### PR TITLE
Add builtin functions for string case changes

### DIFF
--- a/builtins.md
+++ b/builtins.md
@@ -28,6 +28,8 @@ arguments without concern for overflow or underflow.
 | Matrix([[arg\_1\_1, ..., arg\_1\_n], ..., [arg\_m\_1, ..., arg\_m\_n]]), Matrix([arg\_1, ..., arg\_n]) | Convert a list of equal-sized lists into a matrix. Covert a single list into a vector which is automatically interpreted as a row vector or a column vector based on the context. |
 | AtoI(character) | Convert a single ASCII character into an integer. |
 | Caseless(string) | Convert the string into a caseless string |
+| Upper(string or character) | Return the string or character in upper case |
+| Lower(string or character) | Return the string or character in lower case |
 | Char(integer) | Interpret the integer argument as a Unicode code point and return the corresponding character.|
 |Repr(integer) | Return a base 10 string representation of the argument. No equivalent for real numbers is currently defined.|
 |Is\_missing(arg) | Return true if the argument has value `missing`. This is the only way to test for `missing`.|


### PR DESCRIPTION
Added Lower and Upper builtin functions.

The `Upper` function is required to create a proper atom type from a lowercase atom label.
We have not required this function previously because the atom type symbol was case insensitive before cif core commit 9a2b5766. Therefore, the `AtomType` dREL function provided in cif core was able to extract the type symbol from lowercase atom labels as a substring and use it to index into the `atom_type` category. However, now that substring needs to start from a capital letter as the key for `atom_type` is case-sensitive.